### PR TITLE
Release 20200507-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ This library is made available on the Unidata nexus artifacts server (`https://a
 groupId: `edu.wisc.ssec`
 artifactId: `visad-mcidas-slim`
 
+To avoid namespace clashes, a second version of this artifact is published.
+The new artifact is the same as `visad-mcidas-slim`, but the `edu.wisc.ssec.mcidas` package is relocated to `ucar.mcidas`.
+
+groupId: `edu.wisc.ssec`
+artifactId: `visad-mcidas-slim-ucar-ns`
+
 As `visad` itself does not appear to be versioned, this artifact is versioned using the calendar date associated with the build of the artifact and has the form `yyyyMMdd`.
 
 As the case with `visad`, this library is released under the terms of the GNU Library General Public License, Version 2, June 1991.
@@ -31,3 +37,4 @@ As the case with `visad`, this library is released under the terms of the GNU Li
 ## Release History
 
 Release 20200507 :  Based on visad commit [b01355c](https://github.com/visad/visad/commit/b01355c650768ce6459d271df82fd88588c22ead)
+Release 20200507-2 :  Same as release 20200507, but includes a new artifact with the `edu.wisc.ssec.mcidas` package relocated to `ucar.mcidas`.

--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,8 @@ group = "edu.wisc.ssec"
 // Matches Maven's "project.version". Used in MANIFEST.MF for "Implementation-Version".
 // This package, nor it's parent jar visad, isn't really versioned by SSEC
 // We'll assign a version using the build date, as defined in ext
-version = buildDate + "-2"// use this for releases
-//version = buildDate + '-SNAPSHOT' // use this for snapshots
+//version = buildDate // use this for releases
+version = buildDate + '-SNAPSHOT' // use this for snapshots
 
 
 sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,8 @@ group = "edu.wisc.ssec"
 // Matches Maven's "project.version". Used in MANIFEST.MF for "Implementation-Version".
 // This package, nor it's parent jar visad, isn't really versioned by SSEC
 // We'll assign a version using the build date, as defined in ext
-//version = buildDate // use this for releases
-version = buildDate + '-SNAPSHOT' // use this for snapshots
+version = buildDate + "-2"// use this for releases
+//version = buildDate + '-SNAPSHOT' // use this for snapshots
 
 
 sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     // Apply the java-library plugin to add support for Java Library
     id 'java-library'
     id 'maven-publish'
+    id 'com.github.johnrengelman.shadow' version '5.2.0'
 }
 
 ext {
@@ -21,7 +22,7 @@ ext {
 }
 
 // Matches Maven's "project.description".
-description = "A subset of McIDAS packages from VisAD for use by cdm-mcidas."
+description = "A subset of the McIDAS package from VisAD"
 
 // Matches Maven's "project.groupId". Used in MANIFEST.MF for "Implementation-Vendor-Id".
 group = "edu.wisc.ssec"
@@ -78,11 +79,18 @@ jar {
     }
 }
 
+shadowJar {
+    baseName 'visad-mcidas-slim-ucar-ns'
+    classifier ''
+    // relocate the edu.wisc.ssec.mcidas package to ucar.mcidas
+    relocate 'edu.wisc.ssec.mcidas', 'ucar.mcidas'
+}
+
 publishing {
     publications {
         publishSlim(MavenPublication) {
             pom {
-                description = "${-> project.description}"
+                description = "${-> project.description}" + '.'
                 url = "${-> project.gitUrl}"
                 licenses {
                     license {
@@ -96,6 +104,24 @@ publishing {
                 }
             }
             from components.java
+        }
+        shadow(MavenPublication) { publication ->
+            project.shadow.component(publication)
+            artifactId = 'visad-mcidas-slim-ucar-ns'
+            pom {
+                description = "${-> project.description}" + ' for use by cdm-mcidas (edu.wisc.ssec.mcidas package relocated to ucar.mcidas).'
+                url = "${-> project.gitUrl}"
+                licenses {
+                    license {
+                        // This name is the SPDX identifier
+                        name = 'LGPL-2.0-or-later'
+                        url = 'https://www.gnu.org/licenses/old-licenses/lgpl-2.0.en.html'
+                    }
+                }
+                scm {
+                    url = "${-> project.gitUrl}"
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Create a new artifact with the `edu.wisc.ssec.mcidas` package relocated to `ucar.mcidas` to prevent namespace clashes, and cut a second release.