### PR TITLE
Fix resource leak

### DIFF
--- a/core/src/edu/wisc/ssec/mcidas/AreaFile.java
+++ b/core/src/edu/wisc/ssec/mcidas/AreaFile.java
@@ -354,7 +354,13 @@ public class AreaFile implements java.io.Serializable {
     }
     fileok = true;
     position = 0;
-    readMetaData();
+
+    try {
+      readMetaData();
+    } catch (AreaFileException e) {
+      close();
+      throw e;
+    }
   }
 
   /**


### PR DESCRIPTION
Fix resource leak when file is not an `AreaFile` by closing `this.af` if `readMetadata` fails.